### PR TITLE
docs: update paid contributors program

### DIFF
--- a/paid-contributors.md
+++ b/paid-contributors.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-In an effort to ensure the continuous development of Parse Platform, contributors can receive a financial compensation for their contribution. The participation under the program is always clearly defined in scope, budget and time before the approval of participation.
+In an effort to ensure the continuous technical and organizational development of Parse Platform, contributors can receive a financial compensation for their contribution. The participation under the program is always clearly defined in scope, budget and time before the approval of participation.
 
 ## Process
 

--- a/paid-contributors.md
+++ b/paid-contributors.md
@@ -1,20 +1,35 @@
-# Parse Community Paid Contributors
+# Paid Contributors Program
 
 ## Overview
 
-In an effort to maintain the quality and timely development of the Parse Platform, the Parse Community will pay a monthly stipend to contributors who have demonstrated a consistent, positive contribution to the community.
+In an effort to ensure the continuous development of Parse Platform, contributors can receive a financial compensation for their contribution. The participation under the program is always clearly defined in at least scope and budget before the approval of participation.
 
-This is a pilot program whose effectiveness will be evaluated to determine if it should be continued.
+## Process
 
-The goal is to compensate individual contributors for whom the payments will be a material incentive to enable them to continue their contributions.
+1. The Project Management Committee (PMC) identifies the need for a specific contribution under the program.
+2. The PMC either selects a specific person or publishes an open invitation to apply to participate in the program.
+3. The PMC optionally holds a call with the selected individual to elaborate the scope and requirements and answer any questions. This is always conducted for first-time participants, and may be skipped for repeated participants if the scope does not require it and there are no questions from the contributor's side.
+4. The PMC is available through-out the contribution to guide the participant.
+5. The PMC may review agreed milestones in the course of the contribution.
+6. The PMC reviews the contribution, expense claim and contribution records submitted by the participant.
+7. The participant submits an [expense claim](https://opencollective.com/parse-server/expenses/new) with contribution records to the [Parse Platform Open Collective](https://opencollective.com/parse-server).
+8. The PMC approves the expense claim and request the payout from the Open Collective fiscal host.
+9. The fiscal host approves the expense claim and initiates the payout.
 
-Initially, the project management committee will determine by vote who will be eligible for a stipend.  A monthly amount will be agreed to and voted on by the project management committee. Voting will take place publicly on our [community forum](https://community.parseplatform.org) . The number of core contributors receiving funds must be less than a majority of the members.
+## Conditions
 
-Each month the recipient will submit a payment request to our [Open Collective](https://opencollective.com/parse-server) for review and approval.  The payment request should include a brief summary of the months activities to make transparency easy for any observer. Payment requests submitted without having been approved for the program will be denied.
+To ensure financial controlling, the following conditions apply:
+- The program participation has been confirmed by the Project Management Committee in writing, prior to starting any compensated contribution.
+- The participant must join the Parse Slack channel to be reachable for private communication during their participation.
+- The participant submits an expense claim after the contribution materialized.
+- The participant submits contribution records in a provided form together with the expense claim.
+- In case of deliberately filing false expense claims or contribution records, the participant is excluded from the program without compensation and excluded from future participation.
+- The program participation can be confirmed for a maximum period of 3 months after which the participation terminates without action required. Any renewal has to go through the same process of evaluation and confirmation as a first-time participation, and in addition will consider past contribution records.
+- In case of insufficient quality or quantity of contribution, the PMC reserves the right to reduce the amount of compensation. In case of reduction, a proper explanation will be given to the contributor.
+- In rare cases, the Project Management Committee may redact information about a member's program participation or contribution details if it deemed necessary by the PMC. For example, if the contribution is related to a security vulnerability.
+- The Project Management Committee approves or rejects expense claims filed under the program. To avoid any conflict of interest, members of the Project Management Committee can only participate in the program if extraordinary circumstances arise. For example, if no contributors can be found within or outside of the community to make the required contribution in an acceptable form, in urgent and unforeseen situations when timely action is required, or in situations where the task requires confidentiality to prevent detrimental effects for the organization. The primary objective of the program is to engage the broader community, facilitate continuous contribution and leverage community resources. Therefore, rather than participating in the program, it is the Project Management Committee's primary focus to ensure these community resources are formed, maintained and expanded.
 
-## Current Program Members
+These conditions apply to all forms of contributions under the program.
+## Current Program Participants
 
-|         | ![Tom Fox](https://avatars0.githubusercontent.com/u/13188249?s=180&v=4) | ![Diamond Lewis](https://avatars0.githubusercontent.com/u/9830365?s=180&v=4) |
-|---------|:---:|:---:|
-| Name:   | [__Tom Fox__](https://github.com/tomwfox) | [__Diamond Lewis__](https://github.com/dplewis) |
-| Monthly stipend (as of October 2019): | $100 | $600 |
+The list of current participants, the amount of compensation and the dates are made public in the [Open Collective Expenses](https://opencollective.com/parse-server/expenses?type=INVOICE).

--- a/paid-contributors.md
+++ b/paid-contributors.md
@@ -2,13 +2,13 @@
 
 ## Overview
 
-In an effort to ensure the continuous development of Parse Platform, contributors can receive a financial compensation for their contribution. The participation under the program is always clearly defined in at least scope and budget before the approval of participation.
+In an effort to ensure the continuous development of Parse Platform, contributors can receive a financial compensation for their contribution. The participation under the program is always clearly defined in scope, budget and time before the approval of participation.
 
 ## Process
 
 1. The Project Management Committee (PMC) identifies the need for a specific contribution under the program.
 2. The PMC either selects a specific person or publishes an open invitation to apply to participate in the program.
-3. The PMC optionally holds a call with the selected individual to elaborate the scope and requirements and answer any questions. This is always conducted for first-time participants, and may be skipped for repeated participants if the scope does not require it and there are no questions from the contributor's side.
+3. The PMC optionally holds a call with the selected individual to elaborate on scope and conditions, and answer any questions. This is always conducted for first-time participants, and may be skipped for repeated participants.
 4. The PMC is available through-out the contribution to guide the participant.
 5. The PMC may review agreed milestones in the course of the contribution.
 6. The PMC reviews the contribution, expense claim and contribution records submitted by the participant.
@@ -19,17 +19,16 @@ In an effort to ensure the continuous development of Parse Platform, contributor
 ## Conditions
 
 To ensure financial controlling, the following conditions apply:
-- The program participation has been confirmed by the Project Management Committee in writing, prior to starting any compensated contribution.
+- The program participation must be confirmed by the PMC in writing prior to the beginning of contribution.
 - The participant must join the Parse Slack channel to be reachable for private communication during their participation.
-- The participant submits an expense claim after the contribution materialized.
+- The participant submits an expense claim only after the full contribution materialized.
 - The participant submits contribution records in a provided form together with the expense claim.
-- In case of deliberately filing false expense claims or contribution records, the participant is excluded from the program without compensation and excluded from future participation.
+- In case of deliberately or negligently filing false expense claims or contribution records, the participant will be terminated without compensation and the participant excluded from future participation.
 - The program participation can be confirmed for a maximum period of 3 months after which the participation terminates without action required. Any renewal has to go through the same process of evaluation and confirmation as a first-time participation, and in addition will consider past contribution records.
-- In case of insufficient quality or quantity of contribution, the PMC reserves the right to reduce the amount of compensation. In case of reduction, a proper explanation will be given to the contributor.
-- In rare cases, the Project Management Committee may redact information about a member's program participation or contribution details if it deemed necessary by the PMC. For example, if the contribution is related to a security vulnerability.
-- The Project Management Committee approves or rejects expense claims filed under the program. To avoid any conflict of interest, members of the Project Management Committee can only participate in the program if extraordinary circumstances arise. For example, if no contributors can be found within or outside of the community to make the required contribution in an acceptable form, in urgent and unforeseen situations when timely action is required, or in situations where the task requires confidentiality to prevent detrimental effects for the organization. The primary objective of the program is to engage the broader community, facilitate continuous contribution and leverage community resources. Therefore, rather than participating in the program, it is the Project Management Committee's primary focus to ensure these community resources are formed, maintained and expanded.
+- In case of insufficient quality or quantity of contribution, the PMC reserves the right to reduce the previously agreed amount of compensation. In case of reduction, a proper explanation based on specific evidence will be given to the contributor.
+- In rare cases, the PMC may redact or delay the publication of information about a member's program participation or contribution details if it deems necessary to do so. For example, if the contribution is related to a security vulnerability.
+- The PMC approves or rejects expense claims filed under the program. To avoid any conflict of interest, members of the PMC can only participate in the program if extraordinary circumstances arise. For example, if no contributors can be found within or outside of the community to make the required contribution in an acceptable form, in urgent and unforeseen situations when timely action is required, or in situations where the task requires confidentiality to prevent otherwise detrimental consequences for the organization. If no contributors can be found, it is the PMC's focus to ensure that the critically required community resources are recruited as soon as possible to delegate these contributions to resources outside the PMC. The PMC's primary focus is to ensure these community resources are formed, maintained and expanded.
 
-These conditions apply to all forms of contributions under the program.
 ## Current Program Participants
 
 The list of current participants, the amount of compensation and the dates are made public in the [Open Collective Expenses](https://opencollective.com/parse-server/expenses?type=INVOICE).

--- a/paid-contributors.md
+++ b/paid-contributors.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-In an effort to ensure the continuous technical and organizational development of Parse Platform, contributors can receive a financial compensation for their contribution. The participation under the program is always clearly defined in scope, budget and time before the approval of participation.
+In an effort to ensure the continuous technical and organizational development of Parse Platform, contributors can receive financial compensation for their contribution. The participation under the program is clearly defined in scope, budget and time before the approval of participation.
 
 ## Process
 
@@ -12,23 +12,24 @@ In an effort to ensure the continuous technical and organizational development o
 4. The PMC is available through-out the contribution to guide the participant.
 5. The PMC may review agreed milestones in the course of the contribution.
 6. The PMC reviews the contribution, expense claim and contribution records submitted by the participant.
-7. The participant submits an [expense claim](https://opencollective.com/parse-server/expenses/new) with contribution records to the [Parse Platform Open Collective](https://opencollective.com/parse-server).
-8. The PMC approves the expense claim and request the payout from the Open Collective fiscal host.
+7. The participant [submits an expense claim](https://opencollective.com/parse-server/expenses/new) with contribution records to the [Parse Platform Open Collective](https://opencollective.com/parse-server).
+8. The PMC evaluates and approves the expense claim in a majority decision and requests the payout from the Open Collective fiscal host. In case of rejection, the PMC seeks to resolve any dispute with the participant.
 9. The fiscal host approves the expense claim and initiates the payout.
 
 ## Conditions
 
-To ensure financial controlling, the following conditions apply:
-- The program participation must be confirmed by the PMC in writing prior to the beginning of contribution.
+We appreciate the trust financial donors put into the PMC to responsibly manage their funds for the further development of the project. Therefore we apply the following conditions:
+
+- The program participation must be confirmed by the PMC in writing prior to the beginning of the contribution.
 - The participant must join the Parse Slack channel to be reachable for private communication during their participation.
-- The participant submits an expense claim only after the full contribution materialized.
-- The participant submits contribution records in a provided form together with the expense claim.
-- In case of deliberately or negligently filing false expense claims or contribution records, the participant will be terminated without compensation and the participant excluded from future participation.
-- The program participation can be confirmed for a maximum period of 3 months after which the participation terminates without action required. Any renewal has to go through the same process of evaluation and confirmation as a first-time participation, and in addition will consider past contribution records.
-- In case of insufficient quality or quantity of contribution, the PMC reserves the right to reduce the previously agreed amount of compensation. In case of reduction, a proper explanation based on specific evidence will be given to the contributor.
-- In rare cases, the PMC may redact or delay the publication of information about a member's program participation or contribution details if it deems necessary to do so. For example, if the contribution is related to a security vulnerability.
-- The PMC approves or rejects expense claims filed under the program. To avoid any conflict of interest, members of the PMC can only participate in the program if extraordinary circumstances arise. For example, if no contributors can be found within or outside of the community to make the required contribution in an acceptable form, in urgent and unforeseen situations when timely action is required, or in situations where the task requires confidentiality to prevent otherwise detrimental consequences for the organization. If no contributors can be found, it is the PMC's focus to ensure that the critically required community resources are recruited as soon as possible to delegate these contributions to resources outside the PMC. The PMC's primary focus is to ensure these community resources are formed, maintained and expanded.
+- The participant submits an expense claim only after the full contribution materializes.
+- The participant submits contribution records in a provided form, together with the expense claim.
+- In case of deliberately or negligently filing false expense claims or contribution records, the participant will be removed from the program and excluded from future participation.
+- The program participation can be confirmed for a maximum period of 3 months after which the participation terminates without action required. Any renewal has to go through the same process of evaluation and confirmation as a first-time participation, and in addition will consider past contributions.
+- In case of failing to meet the agreed contribution scope in quality, quantity or time, the PMC reserves the right to reduce the previously agreed amount of compensation. In case of reduction, a proper explanation based on specific evidence will be given to the contributor.
+- In rare cases, the PMC may redact or delay the publication of information about a member's program participation or contribution details if it deems it necessary to do so. For example, if the contribution is related to a security vulnerability.
+- The PMC approves or rejects expense claims filed under the program. To avoid any conflict of interest, members of the PMC can only participate in the program if extraordinary circumstances arise. For example, if no contributors can be found within or outside of the community to make the required contribution in an acceptable form, in urgent and unforeseen situations when timely action is required, or in situations where the task requires confidentiality to prevent otherwise detrimental consequences for the organization. If no contributors can be found, it is the PMC's focus to ensure that the critically required community resources are recruited as soon as possible to be able to delegate future contributions to resources outside the PMC. The PMC's primary focus is to facilitate the PCP by ensuring the required community resources are formed, maintained and expanded.
 
 ## Current Program Participants
 
-The list of current participants, the amount of compensation and the dates are made public in the [Open Collective Expenses](https://opencollective.com/parse-server/expenses?type=INVOICE).
+The list of current participants, the amount of compensation and the expense claim dates are made public in the [Open Collective Expenses](https://opencollective.com/parse-server/expenses?type=INVOICE).


### PR DESCRIPTION
The Paid Contributors Program (PCP) was introduces in 2019 as a trial program that requires further review.

While the initial program was rather simple, we have gained experience over the last years to further improve it. This is the improved version, which has been agreed on by the PMC and comes into effect immediately. The new conditions terminate and replace the existing program.